### PR TITLE
Energy Tax for electricity grid

### DIFF
--- a/consumption/settings/settings.price-electricity-grid-general-edit.ctrl.js
+++ b/consumption/settings/settings.price-electricity-grid-general-edit.ctrl.js
@@ -25,6 +25,7 @@ module.exports = /*@ngInject*/ function(
     _this.toDate = undefined;
     _this.annualFee = 0;
     _this.transferFee = 0;
+    _this.energyTax = 0;
 
     calcMetrics = emCalculatedMetrics.forMeter(_this.meterId);
 
@@ -49,6 +50,7 @@ module.exports = /*@ngInject*/ function(
 
           _this.annualFee = calcMetric.params.annual_fee;
           _this.transferFee = calcMetric.params.transfer_fee * 100;
+          _this.energyTax = calcMetric.params.energy_tax * 100;
         }
 
         _this.loading = false;
@@ -89,7 +91,8 @@ module.exports = /*@ngInject*/ function(
       period: from + '-' + to,
       params: {
         annual_fee: _this.annualFee,
-        transfer_fee: _this.transferFee / 100
+        transfer_fee: _this.transferFee / 100,
+        energy_tax: _this.energyTax / 100
       }
     };
 

--- a/consumption/settings/settings.price-electricity-grid-general-edit.tmpl.html
+++ b/consumption/settings/settings.price-electricity-grid-general-edit.tmpl.html
@@ -21,6 +21,14 @@
            ng-model="ctrl.transferFee" />
       </div>
 
+      <div class="item item-divider" translate>Energiskatt (öre / kWh)</div>
+      <div class="item item-input padding-bottom">
+        <input
+          type="number"
+          ng-keyup="ctrl.keyUp($event)"
+          ng-model="ctrl.energyTax" />
+      </div>
+
       <div class="item item-divider" translate>Från</div>
       <div class="item item-input padding-bottom">
          <input

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metry-mobile-app-components",
-  "version": "0.3.9",
+  "version": "0.4.0",
   "description": "Ionic components that make up the Metry mobile apps",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Energy Tax for electricity grid

- Add energy tax field in electricity grid settings menu
- Configure client app to collect data from a custom backend model unique to Borås Elnät
- Increase version number to 0.4.0

## Screenshot
![image](https://user-images.githubusercontent.com/37734235/49874222-3c5cf880-fe1e-11e8-8d62-b9b470ae38e1.png)


## Tally

![image](https://user-images.githubusercontent.com/37734235/49874425-bc835e00-fe1e-11e8-806a-4c55acabb1d1.png)
